### PR TITLE
feat(mobile-ui): restyle injected mobile UI to match the native look

### DIFF
--- a/src/mobile-ui.css
+++ b/src/mobile-ui.css
@@ -117,6 +117,59 @@
   opacity: 1;
 }
 
+/* Added mobile controls (mobile-ui.js) use the app's own icon-button
+   recipe (native .attach: 32x32, tokens) so nothing injected reads as a
+   sticker, and are visible at every width. */
+.fb-ic {
+  display: block;
+  flex: none;
+}
+.fb-folder-attach,
+.fb-files-attach {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--muted, #9a9aa8);
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.fb-folder-attach:hover:not(:disabled),
+.fb-folder-attach:focus-visible,
+.fb-files-attach:hover:not(:disabled),
+.fb-files-attach:focus-visible {
+  background: var(--raised, #24242b);
+  color: var(--text, #e8e8ef);
+  outline: none;
+}
+.fb-spin {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border: 2px solid color-mix(in srgb, var(--muted, #888) 35%, transparent);
+  border-top-color: var(--fb-m-brand, #6b9dff);
+  border-radius: 50%;
+  animation: fb-spin 0.7s linear infinite;
+}
+@keyframes fb-spin {
+  to { transform: rotate(360deg); }
+}
+@keyframes fb-card-in {
+  from { opacity: 0; transform: scale(0.96); }
+  to { opacity: 1; transform: scale(1); }
+}
+.fb-attach-chip .fb-ic {
+  margin-left: 6px;
+}
+
 /* ─────────────── 1000px: mobile layout (phones & small tablets) ────────── */
 @media (max-width: 1000px) {
   /* Cap the composer's auto-growing textarea so typing never reflows the
@@ -447,10 +500,10 @@
     max-height: 40vh;
     overflow-y: auto;
     padding: 8px;
-    border: 1px solid var(--border);
+    border: 1px solid color-mix(in srgb, var(--border, #333) 35%, transparent);
     border-radius: 14px;
-    background: var(--surface-2);
-    box-shadow: 0 10px 28px color-mix(in srgb, var(--shadow) 42%, transparent);
+    background: var(--surface-2, #0d0d0d);
+    box-shadow: 0 10px 28px color-mix(in srgb, var(--shadow, #000) 42%, transparent);
     animation: fb-ctx-in 0.22s cubic-bezier(0.2, 0.8, 0.3, 1);
   }
   /* The native effort menu opens upward from its trigger. That is correct
@@ -482,6 +535,20 @@
     min-height: 46px;
     max-height: 120px;
     border-radius: 10px;
+    border: 1px solid color-mix(in srgb, var(--border, #444) 40%, transparent);
+    background: var(--surface-2, #0d0d0d);
+    color: var(--text, #e8e8ef);
+    caret-color: var(--fb-m-brand, #45d06e);
+    outline: none;
+    transition: border-color 0.15s ease;
+  }
+  .composer textarea:focus-visible {
+    border-color: var(--fb-m-brand-ring, #45d06e);
+    outline: none;
+  }
+  .composer textarea::placeholder {
+    color: var(--muted, #6b6b78);
+    opacity: 0.7;
   }
   .composer-row {
     flex-wrap: wrap;
@@ -492,32 +559,22 @@
   .head-btn {
     min-height: 38px;
   }
-  .fb-folder-attach {
-    align-self: center;
-    padding: 6px 10px;
-    border: 1px solid var(--border, #444);
-    border-radius: 8px;
-    background: var(--surface-2, #1a1a1a);
-    color: var(--muted, #9a9aa8);
-    font: inherit;
-    font-size: 12px;
-    cursor: pointer;
+  /* Native mode switch (Build/Plan) is a 32px control; the touch-target rule
+     above must not inflate its buttons (text would pin to the bottom). */
+  .mode-switch button {
+    min-height: auto;
+    height: auto;
   }
-  .fb-folder-attach:hover:not(:disabled), .fb-folder-attach:focus-visible {
-    border-color: var(--brand, #6b9dff);
-    color: var(--text, #e8e8ef);
-    outline: none;
-  }
-  /* Typing: hide attach + stop to free textarea width (native :has, no JS) */
-  .composer:has(textarea:not(:placeholder-shown)) .composer-row .fb-folder-attach,
+  /* Typing: hide stop to free textarea width (native :has, no JS); the
+     folder attach hides at all widths via the base rule in mobile-ui.css. */
   .composer:has(textarea:not(:placeholder-shown)) .composer-row .stop {
     display: none !important;
   }
   .fb-attach-chips { display:flex; flex-wrap:wrap; gap:6px; padding:6px 10px; }
   .fb-attach-chip { display:inline-flex; align-items:center; gap:6px; padding:6px 10px; border:1px solid var(--border,#333); border-radius:999px; background:var(--surface-2,#1a1a1a); color:var(--text,#eee); font-size:12px; }
   .fb-loading{position:fixed;inset:0;z-index:2147483646;display:grid;place-items:center;background:rgba(7,7,10,.72);backdrop-filter:blur(6px)}
-  .fb-loading-card{padding:18px 22px;border:2px solid #fcee0a;box-shadow:0 0 18px rgba(252,238,10,.55), inset 0 0 12px rgba(252,238,10,.2);background:#0a0a0f;color:#fcee0a;font:700 13px/1 monospace;letter-spacing:.08em;text-transform:uppercase;animation:fb-cyber-pulse 1.1s ease-in-out infinite}
-  @keyframes fb-cyber-pulse{0%,100%{box-shadow:0 0 12px rgba(252,238,10,.4)}50%{box-shadow:0 0 28px rgba(252,238,10,.85)}}
+  .fb-loading-card{display:flex;align-items:center;gap:10px;padding:14px 18px;border:1px solid var(--border,#444);border-radius:10px;background:var(--surface-2,#1a1a1a);color:var(--text,#eee);font:inherit;font-size:13px;box-shadow:0 8px 28px color-mix(in srgb,var(--shadow,#000) 40%,transparent);animation:fb-card-in .18s ease}
+  .fb-loading-card::before{content:'';width:14px;height:14px;border:2px solid color-mix(in srgb,var(--muted,#888) 35%,transparent);border-top-color:var(--fb-m-brand,#6b9dff);border-radius:50%;animation:fb-spin .7s linear infinite}
  }
 
 /* ─────────────────────────── 700px: phones ─────────────────────────────── */
@@ -1505,6 +1562,97 @@ html.fb-pi-active .global-feedback {
   outline: 1px solid var(--focus-ring);
   outline-offset: 1px;
 }
+/* Custom model-filter dropdown (mobile-ui.js enhanceModelFilter): the native
+   <select> renders as a white system picker on Android, so it is wrapped in
+   the app's own popover style. The hidden select stays the value source. */
+.fb-sel-wrap {
+  position: relative;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+.fb-sel-native {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  clip: rect(0 0 0 0) !important;
+  clip-path: inset(50%) !important;
+  white-space: nowrap !important;
+}
+.fb-sel-trigger {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  min-height: 32px;
+  box-sizing: border-box;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 4px 26px 4px 8px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.fb-sel-trigger::after {
+  content: '⌄';
+  position: absolute;
+  right: 8px;
+  color: var(--faint);
+  font-size: 12px;
+}
+.fb-sel-trigger:hover,
+.fb-sel-trigger:focus-visible,
+.fb-sel-trigger[aria-expanded='true'] {
+  border-color: var(--focus-ring);
+  background: var(--raised);
+  outline: none;
+}
+.fb-sel-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  left: 0;
+  z-index: 60;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface-2);
+  box-shadow: 0 12px 26px color-mix(in srgb, var(--shadow) 40%, transparent);
+}
+.fb-sel-menu[hidden] {
+  display: none;
+}
+.fb-sel-option {
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  padding: 7px 8px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.fb-sel-option:hover,
+.fb-sel-option.active {
+  background: var(--raised);
+  color: var(--text);
+}
 .fb-session-menu-filter-empty {
   padding: 10px 8px;
   color: var(--faint);
@@ -2189,15 +2337,20 @@ body {
     );
     border-top: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
   }
+  /* The composer input stays flat and borderless like the desktop app:
+     no translucent pill behind the placeholder, no brand-tinted focus glow.
+     A plain thin outline keeps the focus affordance on keyboards/AT. */
   .composer textarea {
-    background: color-mix(in srgb, var(--surface-2) 76%, transparent);
-    border-color: color-mix(in srgb, var(--border) 80%, transparent);
+    background: transparent;
+    border-color: transparent;
     caret-color: var(--fb-m-brand);
-    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    transition: none;
   }
   .composer textarea:focus {
-    border-color: color-mix(in srgb, var(--fb-m-brand) 55%, transparent);
-    box-shadow: 0 0 0 3px var(--fb-m-brand-ring);
+    border-color: transparent;
+    box-shadow: none;
+    outline: 2px solid color-mix(in srgb, var(--border) 70%, transparent);
+    outline-offset: 1px;
   }
 
   /* Floating model/effort/time pills: gradient glass, brand chevrons, a
@@ -4366,7 +4519,6 @@ html body .new-thread-project-menu .project-option {
   background: color-mix(in srgb, #e36a8a 12%, #191326);
   color: #ff9ab2;
 }
-.fb-pi-mode-toggle,
 .fb-pi-mode-home-tab,
 .fb-pi-mode-new,
 .fb-pi-mode-tab,
@@ -4382,16 +4534,35 @@ html body .new-thread-project-menu .project-option {
 }
 .fb-pi-mode-home-tab { min-width: 58px; margin: 0 4px; padding: 4px 8px; border-radius: 7px; }
 .fb-pi-mode-home-tab.active { border-color: var(--fb-pi-ring); background: var(--fb-pi-accent-soft); color: var(--fb-pi-accent); }
+/* Freebuff/Pi mode toggle lives among the header icon buttons
+   (fb-panel-toggle & co: 44px, borderless, ghost until hover); match them so
+   it never reads as a stray outlined chip in the tab bar. */
 .fb-pi-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   margin-left: 6px;
-  padding: 4px 8px;
-  border-radius: 7px;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
   color: var(--text, #eee);
-  font-weight: 700;
+  font-size: 12px;
+  font-weight: 600;
+}
+.fb-pi-mode-toggle:hover,
+.fb-pi-mode-toggle:active {
+  background: var(--raised, #24242b);
+  color: var(--text, #eee);
+}
+.fb-pi-mode-toggle:focus-visible {
+  outline: 1px solid var(--focus-ring);
+  outline-offset: 1px;
 }
 .fb-pi-mode-toggle[aria-pressed='true'] {
-  border-color: var(--fb-pi-ring);
-  background: var(--fb-pi-accent-soft);
+  background: color-mix(in srgb, var(--fb-pi-accent) 12%, transparent);
   color: var(--fb-pi-accent);
 }
 .fb-pi-mode-new {

--- a/src/mobile-ui.js
+++ b/src/mobile-ui.js
@@ -215,9 +215,24 @@
     }, 80);
   }
 
+  // Inline SVG icons (lucide-style stroke icons, the app's own icon family)
+  // — no emoji, so the added controls render identically on every platform
+  // and read as part of the native UI.
+  var FB_IC_PAPERCLIP = '<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>';
+  var FB_IC_FOLDER = '<path d="M20 20a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2h-7.9a2 2 0 0 1-1.69-.9L9.6 3.9A2 2 0 0 0 7.93 3H4a2 2 0 0 0-2 2v13a2 2 0 0 0 2 2Z"/>';
+  function fbIcon(name) {
+    var paths = {
+      paperclip: FB_IC_PAPERCLIP,
+      folder: FB_IC_FOLDER,
+      check: '<path d="M20 6 9 17l-5-5"/>',
+      x: '<path d="M18 6 6 18"/><path d="m6 6 12 12"/>'
+    };
+    return '<svg class="fb-ic" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' + paths[name] + '</svg>';
+  }
+
   // Remote inject: file chip + @file token (same as local attach, but remote)
   var fbLoadingEl = null;
-  function showFbLoading(label){ try{ hideFbLoading(); var o=document.createElement('div'); o.className='fb-loading'; o.innerHTML='<div class="fb-loading-card">▓ '+(label||'UPLOADING')+' ▓</div>'; document.body.appendChild(o); fbLoadingEl=o; }catch(e){} }
+  function showFbLoading(label){ try{ hideFbLoading(); var o=document.createElement('div'); o.className='fb-loading'; o.innerHTML='<div class="fb-loading-card">'+(label||'Uploading…')+'</div>'; document.body.appendChild(o); fbLoadingEl=o; }catch(e){} }
   function hideFbLoading(){ try{ if(fbLoadingEl&&fbLoadingEl.parentNode) fbLoadingEl.parentNode.removeChild(fbLoadingEl); fbLoadingEl=null; }catch(e){} }
   function ensureAttachChipContainer() {
     var composer = document.querySelector('.fb-pi-panel .fb-pi-composer') || document.querySelector('.composer') || document.querySelector('.fb-pi-composer');
@@ -237,7 +252,8 @@
       if (cc) {
         var chip = document.createElement('span');
         chip.className = 'fb-attach-chip';
-        chip.textContent = path.split('/').pop() + ' ✓';
+        chip.textContent = path.split('/').pop();
+        chip.innerHTML += fbIcon('check');
         chip.title = path;
         cc.appendChild(chip);
         setTimeout(function(){ try{ chip.remove(); if(!cc.children.length) cc.remove(); }catch(e){} }, 6000);
@@ -357,46 +373,67 @@
     });
     input.click();
   }
-  // Always-on (bounded interval, no subtree observer): single Attach button
-  // in the app's composer row — phone picker -> /api/fb/upload -> token.
-  // Folder lives only in the floating card (mobile) / native APK picker.
-  function ensureComposerFolderButton() {
+  // Always-on (bounded interval, no subtree observer): file + folder attach in
+  // the app's composer row at every width. The native paperclip is not reliable
+  // across targets (Desktop shim vs mobile APK), so keep an explicit files button
+  // (freebuffDesktop.pickAttachments, native .attach fallback) plus the folder
+  // button (FreebuffNative.pickFolder / client-side zip).
+  function ensureComposerAttachButtons() {
     var row = document.querySelector('.composer-row');
-    if (!row || row.querySelector('.fb-folder-attach')) return;
-    var filesBtn = document.createElement('button');
-    filesBtn.type = 'button';
-    filesBtn.className = 'fb-folder-attach fb-files-attach';
-    filesBtn.textContent = '\uD83D\uDCCE Attach';
-    filesBtn.setAttribute('aria-label', 'Attach files');
-    filesBtn.addEventListener('click', function (ev) {
-      ev.stopPropagation();
-      var shim = window.freebuffDesktop;
-      if (shim && typeof shim.pickAttachments === 'function') {
-        var btn = filesBtn;
-        var orig = btn.textContent;
-        btn.textContent = '⏳ Uploading…';
-        btn.disabled = true;
-        showFbLoading('UPLOADING');
-        shim.pickAttachments().then(function (files) {
-          hideFbLoading(); btn.textContent = orig;
-          btn.disabled = false;
-          if (!files || !files.length) return;
-          (files || []).forEach(function (f) {
-            injectFileToken(f.path);
+    if (!row) return;
+    if (!row.querySelector('.fb-files-attach')) {
+      var filesBtn = document.createElement('button');
+      filesBtn.type = 'button';
+      filesBtn.className = 'fb-files-attach';
+      filesBtn.innerHTML = fbIcon('paperclip');
+      filesBtn.title = 'Attach files';
+      filesBtn.setAttribute('aria-label', 'Attach files');
+      filesBtn.addEventListener('click', function (ev) {
+        ev.stopPropagation();
+        var shim = window.freebuffDesktop;
+        if (shim && typeof shim.pickAttachments === 'function') {
+          var b = filesBtn; var o = b.innerHTML;
+          b.innerHTML = '<span class="fb-spin" aria-hidden="true"></span>';
+          b.disabled = true;
+          showFbLoading('Uploading…');
+          shim.pickAttachments().then(function (files) {
+            hideFbLoading(); b.innerHTML = o; b.disabled = false;
+            if (!files || !files.length) return;
+            (files || []).forEach(function (f) { injectFileToken(f.path); });
+            try { b.style.outline = '2px solid #2eaa62'; setTimeout(function(){ b.style.outline=''; }, 900); } catch (e) {}
+          }).catch(function (e) {
+            hideFbLoading(); b.innerHTML = o; b.disabled = false;
+            window.alert('File attach failed: ' + (e && e.message || e));
           });
-          // brief green flash so "paste path" reads as uploaded
-          try { btn.style.outline = '2px solid #2eaa62'; setTimeout(function(){ btn.style.outline=''; }, 900); } catch(e){}
-        }).catch(function (e) { btn.textContent = orig; btn.disabled = false; window.alert('File attach failed: ' + (e && e.message || e)); });
-      } else {
+          return;
+        }
         var native = row.querySelector('.attach');
         if (native) native.click();
         else window.alert('File attach unavailable here.');
-      }
-    });
-    row.appendChild(filesBtn);
+      });
+      row.appendChild(filesBtn);
+    }
+    if (!row.querySelector('.fb-folder-attach')) {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'fb-folder-attach';
+      btn.innerHTML = fbIcon('folder');
+      btn.title = 'Attach a folder (zipped)';
+      btn.setAttribute('aria-label', 'Attach a folder (zipped)');
+      btn.addEventListener('click', function (ev) {
+        ev.stopPropagation();
+        var native = window.FreebuffNative;
+        if (native && typeof native.pickFolder === 'function') {
+          native.pickFolder();
+          return;
+        }
+        pickFolderViaInput();
+      });
+      row.appendChild(btn);
+    }
   }
-  if (typeof setInterval !== 'undefined') setInterval(ensureComposerFolderButton, 1500);
-  ensureComposerFolderButton();
+  if (typeof setInterval !== 'undefined') setInterval(ensureComposerAttachButtons, 1500);
+  ensureComposerAttachButtons();
 
   // React mounts large transcripts in many small commits. A separate
   // document-wide observer per mobile feature can monopolize a phone's main
@@ -2593,6 +2630,64 @@
     }, 50);
   }
 
+  // Custom dropdown in the app's own style (the native <select> renders
+  // as a white system picker on Android). The hidden select stays the
+  // source of truth; 'change' still drives the caller's logic.
+  function enhanceSelect(select, cfg) {
+    if (!select || select.dataset[cfg.flag] === 'true') return;
+    select.dataset[cfg.flag] = 'true';
+    var wrap = document.createElement('div');
+    wrap.className = cfg.ns + '-wrap';
+    select.parentNode.insertBefore(wrap, select);
+    wrap.appendChild(select);
+    select.classList.add(cfg.native);
+    select.tabIndex = -1;
+    var trigger = document.createElement('button');
+    trigger.type = 'button';
+    trigger.className = cfg.ns + '-trigger';
+    trigger.setAttribute('aria-haspopup', 'listbox');
+    trigger.setAttribute('aria-expanded', 'false');
+    var menu = document.createElement('div');
+    menu.className = cfg.ns + '-menu';
+    menu.setAttribute('role', 'listbox');
+    menu.hidden = true;
+    wrap.insertBefore(trigger, select);
+    wrap.appendChild(menu);
+    function close() { menu.hidden = true; trigger.setAttribute('aria-expanded', 'false'); }
+    function sync() {
+      var option = select.options[select.selectedIndex];
+      trigger.textContent = option ? option.textContent : cfg.fallback;
+      menu.textContent = '';
+      Array.prototype.forEach.call(select.options, function (item) {
+        var choice = document.createElement('button');
+        choice.type = 'button';
+        choice.className = cfg.ns + '-option' + (item.value === select.value ? ' active' : '');
+        choice.setAttribute('role', 'option');
+        choice.setAttribute('aria-selected', String(item.value === select.value));
+        choice.textContent = item.textContent;
+        choice.addEventListener('click', function () {
+          select.value = item.value;
+          select.dispatchEvent(new Event('change', { bubbles: true }));
+          close();
+          sync();
+        });
+        menu.appendChild(choice);
+      });
+    }
+    trigger.addEventListener('click', function (event) {
+      event.stopPropagation();
+      var open = menu.hidden;
+      document.querySelectorAll('.' + cfg.ns + '-menu').forEach(function (other) { other.hidden = true; });
+      menu.hidden = !open;
+      trigger.setAttribute('aria-expanded', String(open));
+      sync();
+    });
+    document.addEventListener('click', function (event) { if (!wrap.contains(event.target)) close(); });
+    select.addEventListener('change', sync);
+    select[cfg.syncKey] = sync;
+    sync();
+  }
+
   // Session switcher (mobile): the tab strip is hidden on phones (slim
   // header), so switching between open sessions needs a dropdown. A header
   // button opens a menu listing the open session tabs; picking one clicks the
@@ -2925,6 +3020,7 @@
         }
         modelFilterValue = selected;
         modelFilter.value = selected;
+        if (modelFilter._fbSelSync) modelFilter._fbSelSync();
         applySessionModelFilter();
       }
       // Recent (closed) sessions from the app's own catalog API, for the
@@ -3061,6 +3157,13 @@
         filterRow.appendChild(filterLabel);
         filterRow.appendChild(modelFilter);
         menu.appendChild(filterRow);
+        enhanceSelect(modelFilter, {
+          ns: 'fb-sel',
+          native: 'fb-sel-native',
+          flag: 'fbSelEnhanced',
+          fallback: 'All models',
+          syncKey: '_fbSelSync',
+        });
         modelFilterEmpty = document.createElement('div');
         modelFilterEmpty.className = 'fb-session-menu-filter-empty';
         modelFilterEmpty.setAttribute('role', 'status');
@@ -3502,7 +3605,7 @@
           var check = document.createElement('span');
           check.className = 'fb-theme-check';
           check.setAttribute('aria-hidden', 'true');
-          check.textContent = '✓';
+          check.innerHTML = fbIcon('check');
           option.appendChild(swatch);
           option.appendChild(label);
           option.appendChild(check);
@@ -4184,7 +4287,7 @@
           actionBtn(
             'attach',
             'Attach files, photos, or a folder',
-            '<path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>',
+            FB_IC_PAPERCLIP,
             function () {
             var shim = window.freebuffDesktop;
             if (shim && typeof shim.pickAttachments === 'function') {
@@ -4206,8 +4309,8 @@
         wrap.appendChild(
           actionBtn(
             'folder',
-            'Attach a folder (zipped) \uD83D\uDCC2',
-            '<text x="12" y="16" text-anchor="middle" font-size="14">\uD83D\uDCC2</text>',
+            'Attach a folder (zipped)',
+            FB_IC_FOLDER,
             function () {
               var native = window.FreebuffNative;
               if (native && typeof native.pickFolder === 'function') native.pickFolder();
@@ -4924,6 +5027,17 @@
     // was unmounted (thread switch); never re-parent a still-connected node.
     var tb = document.querySelector('.thread-bottom');
     if (tb && !msgToggle.isConnected) tb.appendChild(msgToggle);
+    // The question dock (ask_questions) owns the top-right corner of
+    // thread-bottom: its pager shows there when 2+ questions are pending.
+    // Yield while a dock is visible, whatever the viewport — width was the
+    // wrong discriminator (tablets > 1000px still collided). The observer
+    // below re-runs this scan on dock mount/unmount, so the pill returns
+    // automatically once the questions are answered.
+    var qDock = document.querySelector('.question-dock');
+    if (qDock && qDock.offsetParent !== null) {
+      if (msgToggle.style.display !== 'none') msgToggle.style.display = 'none';
+      return;
+    }
     var long = 0;
     var collapsed = 0;
     var bubbles = document.querySelectorAll('.msg.user .bubble');
@@ -6209,60 +6323,13 @@
           }
         };
       }
-      function enhancePiSelect(select) {
-        if (!select || select.dataset.fbPiEnhanced === 'true') return;
-        select.dataset.fbPiEnhanced = 'true';
-        var wrap = document.createElement('div');
-        wrap.className = 'fb-pi-select-wrap';
-        select.parentNode.insertBefore(wrap, select);
-        wrap.appendChild(select);
-        select.classList.add('fb-pi-native-select');
-        select.tabIndex = -1;
-        var trigger = document.createElement('button');
-        trigger.type = 'button';
-        trigger.className = 'fb-pi-select-trigger';
-        trigger.setAttribute('aria-haspopup', 'listbox');
-        trigger.setAttribute('aria-expanded', 'false');
-        var menu = document.createElement('div');
-        menu.className = 'fb-pi-select-menu';
-        menu.setAttribute('role', 'listbox');
-        menu.hidden = true;
-        wrap.insertBefore(trigger, select);
-        wrap.appendChild(menu);
-        function close() { menu.hidden = true; trigger.setAttribute('aria-expanded', 'false'); }
-        function sync() {
-          var option = select.options[select.selectedIndex];
-          trigger.textContent = option ? option.textContent : 'Choose…';
-          menu.textContent = '';
-          Array.prototype.forEach.call(select.options, function (item) {
-            var choice = document.createElement('button');
-            choice.type = 'button';
-            choice.className = 'fb-pi-select-option' + (item.value === select.value ? ' active' : '');
-            choice.setAttribute('role', 'option');
-            choice.setAttribute('aria-selected', String(item.value === select.value));
-            choice.textContent = item.textContent;
-            choice.addEventListener('click', function () {
-              select.value = item.value;
-              select.dispatchEvent(new Event('change', { bubbles: true }));
-              close();
-              sync();
-            });
-            menu.appendChild(choice);
-          });
-        }
-        trigger.addEventListener('click', function (event) {
-          event.stopPropagation();
-          var open = menu.hidden;
-          document.querySelectorAll('.fb-pi-select-menu').forEach(function (other) { other.hidden = true; });
-          menu.hidden = !open;
-          trigger.setAttribute('aria-expanded', String(open));
-          sync();
-        });
-        document.addEventListener('click', function (event) { if (!wrap.contains(event.target)) close(); });
-        select.addEventListener('change', sync);
-        select._fbPiSync = sync;
-        sync();
-      }
+      var piSelectCfg = {
+        ns: 'fb-pi-select',
+        native: 'fb-pi-native-select',
+        flag: 'fbPiEnhanced',
+        fallback: 'Choose…',
+        syncKey: '_fbPiSync',
+      };
       function renderAuthProviders() {
         if (!controls) return;
         var select = controls.querySelector('.fb-pi-login-provider');
@@ -7272,7 +7339,9 @@
         wallpaperSection.appendChild(wallApply);
         wallpaperSection.appendChild(wallNote);
         controls.appendChild(wallpaperSection);
-        [scopeSelect, modelSelect, thinkingSelect, authMethod, authProvider].forEach(enhancePiSelect);
+        [scopeSelect, modelSelect, thinkingSelect, authMethod, authProvider].forEach(function (sel) {
+          enhanceSelect(sel, piSelectCfg);
+        });
         settingsScrim = document.createElement('button');
         settingsScrim.type = 'button';
         settingsScrim.className = 'fb-pi-settings-scrim';
@@ -7296,16 +7365,16 @@
         var piAttachButton = document.createElement('button');
         piAttachButton.type = 'button';
         piAttachButton.className = 'fb-pi-attach';
-        piAttachButton.textContent = '\uD83D\uDCCE';
+        piAttachButton.innerHTML = fbIcon('paperclip');
         piAttachButton.title = 'Attach files';
         piAttachButton.setAttribute('aria-label', 'Attach files');
         piAttachButton.addEventListener('click', function () {
           var shim = window.freebuffDesktop;
           if (shim && typeof shim.pickAttachments === 'function') {
-            var b = piAttachButton; var o = b.textContent; b.textContent = '⏳'; b.disabled = true;
+            var b = piAttachButton; var o = b.innerHTML; b.innerHTML = '<span class="fb-spin" aria-hidden="true"></span>'; b.disabled = true;
             showFbLoading('UPLOADING');
             shim.pickAttachments().then(function (files) {
-              hideFbLoading(); b.textContent = o; b.disabled = false;
+              hideFbLoading(); b.innerHTML = o; b.disabled = false;
               if (!files || !files.length) return;
               (files || []).forEach(function (f) {
                 var tok = '@file ' + f.path;
@@ -7320,18 +7389,18 @@
                   promptInput && promptInput.focus();
                   // chip above Pi composer
                   var cc = ensureAttachChipContainer();
-                  if (cc) { var chip=document.createElement('span'); chip.className='fb-attach-chip'; chip.textContent=f.path.split('/').pop()+' ✓'; cc.appendChild(chip); setTimeout(function(){try{chip.remove();if(!cc.children.length)cc.remove();}catch(e){}},6000); }
+                  if (cc) { var chip=document.createElement('span'); chip.className='fb-attach-chip'; chip.textContent=f.path.split('/').pop(); chip.innerHTML+=fbIcon('check'); cc.appendChild(chip); setTimeout(function(){try{chip.remove();if(!cc.children.length)cc.remove();}catch(e){}},6000); }
                 } catch (e) { injectFileToken(f.path); }
               });
-            }).catch(function (e) { b.textContent = o; b.disabled = false; window.alert('File attach failed: ' + (e && e.message || e)); });
+            }).catch(function (e) { b.innerHTML = o; b.disabled = false; window.alert('File attach failed: ' + (e && e.message || e)); });
           } else window.alert('File attach unavailable here.');
         });
         form.appendChild(piAttachButton);
         var piFolderButton = document.createElement('button');
         piFolderButton.type = 'button';
         piFolderButton.className = 'fb-pi-attach-url';
-        piFolderButton.textContent = '\uD83D\uDCC2';
-        piFolderButton.title = 'Attach a folder as .zip (or files: use 📎 in the main chat)';
+        piFolderButton.innerHTML = fbIcon('folder');
+        piFolderButton.title = 'Attach a folder as .zip (files attach lives in the main chat)';
         piFolderButton.setAttribute('aria-label', 'Attach a folder (zipped)');
         piFolderButton.addEventListener('click', function () {
           var native = window.FreebuffNative;
@@ -7583,7 +7652,7 @@
       card.innerHTML =
         '<div class="fb-ad-card-head">' +
         '<span class="fb-ad-title">' + esc(ad.title || 'Ad') + '</span>' +
-        '<button type="button" class="fb-ad-close" aria-label="Close ad">✕</button>' +
+        '<button type="button" class="fb-ad-close" aria-label="Close ad">' + fbIcon('x') + '</button>' +
         '</div>' +
         '<div class="fb-ad-copy">' + esc(ad.copy || '') + '</div>' +
         (ad.host


### PR DESCRIPTION
My agent and I reworked the old design of the injected elements that stood out from Freebuff's native style — the agent's report is below:

## What
Every control the mobile layer (mobile-ui.js/css, served by the tailnet proxy) injects into the Freebuff UI now uses the app's own visual language. Previously these controls stood out: emoji glyphs, boxed buttons, a white Android-native `<select>`, and composer layout drift.

## Changes
- Attach/folder button — bare 32px folder SVG icon styled like the native paperclip (no border/background box, hover fill only); stays visible while typing.
- No more emoji — 📎/⏳/✓/✕ replaced with inline SVG icons and a CSS spinner; the yellow "cyberpunk" upload loader became a neutral token-based card.
- Composer textarea — flat transparent surface (no pill behind the placeholder), thin neutral focus outline instead of the green glow.
- Build/Plan — text no longer pinned to the bottom (mode-switch excluded from the touch-target rule).
- Pi corner button ("Freebuff"/"Pi") — restyled as a 44px header icon-row neighbor: no border, transparent, hover/active fills.
- All-models session filter — custom dropdown in the app's popover style replaces the white system `<select>`; the hidden native select stays the source of truth.
- Expand all pill — hides while the question dock is open (was covering the question pager).
- Dedupe — the two near-identical select enhancers (session filter + Pi settings) merged into one `enhanceSelect(select, cfg)`; CSS fully overridden by later rules removed.

## Testing
Verified live on the tailnet proxy with Playwright at 900×800: folder button icon-only 32×38, textarea transparent with neutral focus outline, mode-switch 24px centered, All-models dropdown opens and selects, Pi settings renders 5 enhanced selects. Zero emoji remnants, no JS errors (only a benign 404), `node --check` clean.
