### PR TITLE
fix(ci): unblock webview release, relay-integration verify and debug E2E

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -414,6 +414,7 @@ jobs:
 
       - name: Build signed release APK
         shell: bash
+        working-directory: android
         run: |
           set -euo pipefail
           # -PfreebuffPairingOrigin/-PfreebuffWebOrigin stay empty so the

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -13,6 +13,14 @@ val defaultWebOrigin = providers.gradleProperty("freebuffWebOrigin")
     .orElse("")
     .get()
     .replace("\"", "")
+// The E2E tunnel is a Phase 1 prototype (docs/e2e-tunnel.md): the desktop
+// agent does not join the rendezvous yet, so the app must not auto-enter
+// tunnel mode on a pairing that happens to carry tunnel credentials. Gate it
+// behind an opt-in build flag; the production HTTPS relay path stays default.
+val tunnelEnabled = providers.gradleProperty("freebuffTunnelEnabled")
+    .orElse("0")
+    .get()
+    .trim() == "1"
 
 // Release signing. Pass freebuffKeystorePath/Password and freebuffKeyAlias/
 // Password to sign with a production keystore (CI injects them from the
@@ -60,6 +68,7 @@ android {
         // generic test builds bind to the exact HTTPS origin carried by the QR.
         buildConfigField("String", "DEFAULT_WEB_ORIGIN", "\"$defaultWebOrigin\"")
         buildConfigField("String", "DEFAULT_PAIRING_ORIGIN", "\"$defaultPairingOrigin\"")
+        buildConfigField("boolean", "TUNNEL_ENABLED", "$tunnelEnabled")
     }
 
     buildTypes {

--- a/android/app/src/main/java/com/freebuff/mobile/MainActivity.kt
+++ b/android/app/src/main/java/com/freebuff/mobile/MainActivity.kt
@@ -355,7 +355,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun loadRemoteUi(session: PairingSession) {
-        if (session.tunnelEnabled) {
+        if (session.tunnelEnabled && BuildConfig.TUNNEL_ENABLED) {
             loadRemoteUiViaTunnel(session)
             return
         }

--- a/android/app/src/main/java/com/freebuff/mobile/TurnNotificationService.kt
+++ b/android/app/src/main/java/com/freebuff/mobile/TurnNotificationService.kt
@@ -103,7 +103,13 @@ class TurnNotificationService : Service() {
                 Log.w(TAG, "events stream error: ${error.message}")
             }
             if (!running.get()) return
-            Thread.sleep(backoffMs)
+            try {
+                Thread.sleep(backoffMs)
+            } catch (_: InterruptedException) {
+                // shutdownNow() interrupts the loop thread on stop; exit
+                // cleanly instead of crashing the process mid-instrumentation.
+                return
+            }
             backoffMs = (backoffMs * 2).coerceAtMost(60_000L)
         }
     }

--- a/src/install-mobile-connect.js
+++ b/src/install-mobile-connect.js
@@ -1526,10 +1526,10 @@ function collectProblems(desktopDir, options = {}) {
     }
     const raw = body;
     // The proxy patches the bundle at serve time, so the on-disk file won't
-    // carry the markers. Run it through patchBundle() to see what's actually
+    // carry the markers. Run it through patchBundleInfo() to see what's actually
     // served, and treat obsolete markers (removed upstream in a new app
     // version, e.g. 0.0.71) as non-errors.
-    const patched = proxy.patchBundle(body);
+    const patched = proxy.patchBundleInfo(body);
     body = patched.body;
     const obsolete = patched.obsolete || [];
     const missing = names.filter((mark, index) => !body.includes(fixed[index]) && !obsolete.includes(names[index]));


### PR DESCRIPTION
Four independent fixes that were breaking the Android CI pipeline. Each is a real bug, not a flake.

## Changes

1. **fix(ci): run webview release build from `android/` working dir**
   The `Build signed release APK` step ran Gradle from the repo root, but the Gradle build lives in `android/` (every other Gradle step sets `working-directory: android`). The webview release APK never built.

2. **fix(install): verify bundle markers via `patchBundleInfo`, not `patchBundle`**
   `patchBundle()` returns the patched **string**; `collectProblems()` in `install-mobile-connect.js` read `patched.body`/`patched.obsolete` as if it returned an object. `77b89d8` changed the contract but missed this call site, so `verifyUiStack` crashed with `Cannot read properties of undefined (reading 'includes')` whenever UI bundles exist — breaking the `relay-integration` job.

3. **fix(android): gate E2E tunnel prototype behind opt-in build flag**
   The tunnel is a Phase 1 spike (`docs/e2e-tunnel.md`) whose desktop side never joins the rendezvous, yet `PairingStore` always mints a `tunnelToken`, so **every** pairing auto-switched the WebView to the loopback tunnel (`http://127.0.0.1:<port>`) and the relay UI never loaded — breaking the debug E2E (`activityClaimsPairingAndLoadsAuthenticatedRelayUi` asserts the HTTPS relay origin). `TUNNEL_ENABLED` now defaults to `false` (production HTTPS relay path); the prototype can be enabled with `-PfreebuffTunnelEnabled=1`.

4. **fix(android): exit cleanly when turn-notification loop thread is interrupted**
   `Thread.sleep` in `runEventLoop` sat outside the try/catch, so `executor.shutdownNow()` on service stop threw an uncaught `InterruptedException` that crashed the whole process — killing the instrumentation run and failing the in-flight smoke test with an empty failure.

## Testing

- [x] `install-mobile-connect.test.js` — failing `verify` test passes with fix 2 (local)
- [x] `relay-integration` CI job — **green** (verified on run 32902380195)
- [x] `debug-apk` CI job — E2E + security tests pass with fixes 3–4 (run 32902380195; smoke test was the victim of the fix-4 process crash, not a real assertion)
- [x] `release-apk` — verified green in an earlier run with fix 1